### PR TITLE
fix(public-service): prevent SQL injection in addUser via parameterized queries

### DIFF
--- a/mail-worker/src/service/public-service.js
+++ b/mail-worker/src/service/public-service.js
@@ -135,14 +135,21 @@ const publicService = {
 				type = roleRow ? roleRow.roleId : type;
 			}
 
-			const userSql = `INSERT INTO user (email, password, salt, type, os, browser, active_ip, create_ip, device, active_time, create_time)
-			VALUES ('${email}', '${hash}', '${salt}', '${type}', '${os}', '${browser}', '${activeIp}', '${activeIp}', '${device}', '${activeTime}', '${activeTime}')`
+			const userName = emailUtils.getName(email);
 
-			const accountSql = `INSERT INTO account (email, name, user_id)
-			VALUES ('${email}', '${emailUtils.getName(email)}', 0);`;
+			userList.push(
+				c.env.db.prepare(
+					`INSERT INTO user (email, password, salt, type, os, browser, active_ip, create_ip, device, active_time, create_time)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+				).bind(email, hash, salt, type, os, browser, activeIp, activeIp, device, activeTime, activeTime)
+			);
 
-			userList.push(c.env.db.prepare(userSql));
-			userList.push(c.env.db.prepare(accountSql));
+			userList.push(
+				c.env.db.prepare(
+					`INSERT INTO account (email, name, user_id)
+			VALUES (?, ?, 0);`
+				).bind(email, userName)
+			);
 
 		}
 


### PR DESCRIPTION
## Summary

This fixes a SQL injection vulnerability (CWE-89) in the `addUser()` function in `mail-worker/src/service/public-service.js`. The two INSERT statements used JavaScript template literals to interpolate user-controlled values directly into the SQL string, then passed the result to `c.env.db.prepare()` without using `.bind()` for parameterization.

## Vulnerability Details

**Affected file:** `mail-worker/src/service/public-service.js` (lines 138–142 before this fix)

**Root cause:** The original code built SQL like this:

```js
const userSql = `INSERT INTO user (...) VALUES ('${email}', '${hash}', ...)`
c.env.db.prepare(userSql)   // no .bind() — SQL is fully baked from string interpolation
```

All interpolated values end up as literal SQL text, which means any value containing SQL metacharacters (single quotes, comment sequences, etc.) can alter the query structure.

**Primary injection vector — the `email` field:**

The `isEmail()` validator uses this regex:

```
/^[a-zA-Z0-9!#$%&'*+/=?^_`{|}~.-]+@([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/
```

This intentionally allows single quotes (`'`), double dashes (`--`), and pipe characters (`||`) in the local part — all of which are valid per RFC 5321 but are also SQL metacharacters. An email like `a'--@target-domain.com` passes both the `isEmail()` check and the domain validation (`getDomain()` returns `target-domain.com`, which can match a configured domain), while injecting into the SQL as `VALUES ('a'--@...', ...)` where `--` comments out the remainder of the statement.

**Auth requirement — public API token, not admin credentials:**

The `/public/addUser` endpoint is gated by a "public token" — a UUID retrieved from Cloudflare KV. This token is generated once by an admin via `/public/genToken` and is designed to be shared with external services for batch user creation (documented as the "Open API" feature). The token has no expiration. An attacker who obtains this token (e.g. from a misconfigured third-party integration or leaked configuration) can call `addUser()` without the admin password. SQL injection then allows reading arbitrary database contents, modifying records, or deleting data — a significant privilege escalation beyond what the public token alone permits.

## Proof of Concept

1. Obtain a public API token (the UUID stored at the `PUBLIC_KEY` KV key), or generate one via the admin endpoint:

```bash
# Admin generates the token (requires admin credentials)
curl -X POST https://<instance>/public/genToken \
  -H "Content-Type: application/json" \
  -d '{"email":"admin@example.com","password":"adminpass"}'
# Response: {"data":{"token":"<uuid>"}}
```

2. Send a crafted payload to `/public/addUser` using the public token:

```bash
curl -X POST https://<instance>/public/addUser \
  -H "Content-Type: application/json" \
  -H "Authorization: <public-token-uuid>" \
  -d '{
    "list": [{
      "email": "test'\''--@configured-domain.com",
      "password": "anything"
    }]
  }'
```

In the original code, this produces SQL like:

```sql
INSERT INTO user (email, password, salt, type, ...) VALUES ('test'--@configured-domain.com', ...)
```

The `'` closes the string literal early and `--` comments out the rest of the line, causing a syntax error (confirming injection). More sophisticated payloads using `'||<subquery>||'` or `UNION`-based techniques can extract data from other tables.

You can verify the regex allows these characters:

```js
const regex = /^[a-zA-Z0-9!#$%&'*+/=?^_`{|}~.-]+@([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/;
console.log(regex.test("test'--@example.com"));   // true
console.log(regex.test("a'OR'1'='1@example.com")); // true
```

## Fix Description

Both INSERT statements now use parameterized queries with `?` placeholders and `.bind()`:

```js
c.env.db.prepare(
  `INSERT INTO user (email, password, salt, type, os, browser, active_ip, create_ip, device, active_time, create_time)
   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
).bind(email, hash, salt, type, os, browser, activeIp, activeIp, device, activeTime, activeTime)
```

```js
c.env.db.prepare(
  `INSERT INTO account (email, name, user_id) VALUES (?, ?, 0);`
).bind(email, userName)
```

This ensures all values are passed as bound parameters and never interpolated into the SQL string, regardless of what characters they contain.

## Testing

- Verified the diff is minimal: 1 file changed, 13 insertions, 6 deletions.
- Confirmed no other SQL injection patterns remain in the codebase (all other `prepare()` calls either use `.bind()` or contain only static SQL with no interpolated variables).
- Confirmed the `email` regex validator (`isEmail()`) passes SQL metacharacters (`'`, `--`, `||`), validating the injection vector.
- Confirmed the fix preserves the original column order and values — the parameterized queries are a direct, behavior-preserving replacement.

## Adversarial Review

Before submitting, we attempted to disprove this finding. We checked whether the `isEmail()` regex would block SQL metacharacters — it doesn't, as the RFC-compliant character class includes `'`, `--`, and `||`. We verified whether the public token auth requirement makes exploitation unrealistic — it doesn't, because the token is designed to be shared with external services, has no expiration, and possession of it alone does not grant the database-level access that SQL injection provides. We also considered whether the Cloudflare D1 runtime sandboxes queries in a way that would prevent injection — D1 uses standard SQLite semantics and `prepare()` without `.bind()` offers no protection against string-interpolated SQL.