### PR TITLE
feat: add Bark push notification for received emails

### DIFF
--- a/mail-vue/src/i18n/en.js
+++ b/mail-vue/src/i18n/en.js
@@ -345,6 +345,15 @@ const en = {
     clientId: 'Client ID',
     clientSecret: 'Client Secret',
     notOwner: 'Base email does not belong to you',
+    barkPush: 'Bark Push',
+    barkUrl: 'Bark URL',
+    barkUrlPlaceholder: 'https://api.day.app/your_key',
+    barkUrlDesc: 'Enter your Bark push URL to receive notifications on your phone when emails arrive',
+    barkUrlHelp: 'How to get it?',
+    barkTestSuccess: 'Test push sent',
+    barkTestFail: 'Test push failed, please check the URL',
+    barkUrlSaved: 'Bark URL saved',
+    barkUrlEmpty: 'Please enter Bark URL first',
 }
 
 export default en

--- a/mail-vue/src/i18n/zh.js
+++ b/mail-vue/src/i18n/zh.js
@@ -345,5 +345,14 @@ const zh = {
     clientId: '客户端 ID',
     clientSecret: '客户端密钥',
     notOwner: '基础邮箱不属于您',
+    barkPush: 'Bark 推送',
+    barkUrl: 'Bark URL',
+    barkUrlPlaceholder: 'https://api.day.app/your_key',
+    barkUrlDesc: '填写 Bark 推送 URL，收到邮件时推送通知到手机',
+    barkUrlHelp: '如何获取？',
+    barkTestSuccess: '测试推送已发送',
+    barkTestFail: '测试推送失败，请检查 URL',
+    barkUrlSaved: 'Bark URL 已保存',
+    barkUrlEmpty: '请先填写 Bark URL',
 }
 export default zh

--- a/mail-vue/src/request/my.js
+++ b/mail-vue/src/request/my.js
@@ -12,3 +12,11 @@ export function userDelete() {
     return http.delete('/my/delete')
 }
 
+export function getBarkUrl() {
+    return http.get('/my/barkUrl')
+}
+
+export function setBarkUrl(barkUrl) {
+    return http.put('/my/barkUrl', { barkUrl })
+}
+

--- a/mail-vue/src/views/setting/index.vue
+++ b/mail-vue/src/views/setting/index.vue
@@ -30,6 +30,21 @@
         </div>
       </div>
     </div>
+    <div class="bark-section">
+      <div class="title">{{$t('barkPush')}}</div>
+      <div class="bark-desc">
+        {{$t('barkUrlDesc')}}
+        <a href="https://bark.day.app/" target="_blank" class="bark-help">{{$t('barkUrlHelp')}}</a>
+      </div>
+      <div class="bark-input-row">
+        <el-input
+            v-model="barkUrl"
+            :placeholder="$t('barkUrlPlaceholder')"
+            clearable
+        />
+        <el-button type="primary" :loading="barkSaveLoading" @click="saveBarkUrl">{{$t('save')}}</el-button>
+      </div>
+    </div>
     <div class="language">
       <div class="title">{{$t('language')}}</div>
       <el-select
@@ -62,13 +77,14 @@
 </template>
 <script setup>
 import {reactive, ref, defineOptions} from 'vue'
-import {resetPassword, userDelete} from "@/request/my.js";
+import {resetPassword, userDelete, getBarkUrl, setBarkUrl} from "@/request/my.js";
 import {useUserStore} from "@/store/user.js";
 import router from "@/router/index.js";
 import {accountSetName} from "@/request/account.js";
 import {useAccountStore} from "@/store/account.js";
 import {useI18n} from "vue-i18n";
 import {useSettingStore} from "@/store/setting.js";
+import {onMounted} from "vue";
 
 const { t } = useI18n()
 const accountStore = useAccountStore()
@@ -78,6 +94,8 @@ const setPwdLoading = ref(false)
 const setNameShow = ref(false)
 const accountName = ref(null)
 const langSelect = ref(settingStore.lang)
+const barkUrl = ref('')
+const barkSaveLoading = ref(false)
 
 defineOptions({
   name: 'setting'
@@ -132,6 +150,27 @@ function changeLang(lang) {
   localStorage.setItem('setting', JSON.stringify({...setting, lang}))
   window.location.reload()
 }
+
+function saveBarkUrl() {
+  if (barkSaveLoading.value) return
+  barkSaveLoading.value = true
+  setBarkUrl(barkUrl.value).then(() => {
+    ElMessage({
+      message: t('barkUrlSaved'),
+      type: 'success',
+      plain: true,
+    })
+    barkSaveLoading.value = false
+  }).catch(() => {
+    barkSaveLoading.value = false
+  })
+}
+
+onMounted(() => {
+  getBarkUrl().then(res => {
+    barkUrl.value = res.barkUrl || ''
+  })
+})
 
 const pwdShow = ref(false)
 const form = reactive({
@@ -273,6 +312,40 @@ function submitPwd() {
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;
+      }
+    }
+  }
+
+  .bark-section {
+    font-size: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+    margin-bottom: 40px;
+
+    .title {
+      font-size: 18px;
+      font-weight: bold;
+    }
+
+    .bark-desc {
+      color: var(--regular-text-color);
+      line-height: 1.6;
+
+      .bark-help {
+        color: #4dabff;
+        text-decoration: none;
+        margin-left: 4px;
+      }
+    }
+
+    .bark-input-row {
+      display: flex;
+      gap: 10px;
+      max-width: 600px;
+
+      .el-input {
+        flex: 1;
       }
     }
   }

--- a/mail-worker/src/api/my-api.js
+++ b/mail-worker/src/api/my-api.js
@@ -18,4 +18,14 @@ app.delete('/my/delete', async (c) => {
 	return c.json(result.ok());
 });
 
+app.get('/my/barkUrl', async (c) => {
+	const barkUrl = await userService.getBarkUrl(c, userContext.getUserId(c));
+	return c.json(result.ok({ barkUrl }));
+});
+
+app.put('/my/barkUrl', async (c) => {
+	await userService.setBarkUrl(c, await c.req.json(), userContext.getUserId(c));
+	return c.json(result.ok());
+});
+
 

--- a/mail-worker/src/email/email.js
+++ b/mail-worker/src/email/email.js
@@ -11,6 +11,7 @@ import roleService from '../service/role-service';
 import userService from '../service/user-service';
 import telegramService from '../service/telegram-service';
 import aiService from '../service/ai-service';
+import barkService from '../service/bark-service';
 
 export async function email(message, env, ctx) {
 
@@ -152,6 +153,12 @@ export async function email(message, env, ctx) {
 		}
 
 		emailRow = await emailService.completeReceive({ env }, account ? emailConst.status.RECEIVE : emailConst.status.NOONE, emailRow.emailId);
+
+
+		//Bark 推送通知
+		if (account && emailRow.type === emailConst.type.RECEIVE) {
+			await barkService.notifyReceive({ env }, emailRow);
+		}
 
 
 		if (ruleType === settingConst.ruleType.RULE) {

--- a/mail-worker/src/entity/user.js
+++ b/mail-worker/src/entity/user.js
@@ -17,6 +17,7 @@ const user = sqliteTable('user', {
 	sort: text('sort').default(0),
 	sendCount: text('send_count').default(0),
 	regKeyId: integer('reg_key_id').default(0).notNull(),
+	barkUrl: text('bark_url').default('').notNull(),
 	isDel: integer('is_del').default(0).notNull()
 });
 export default user

--- a/mail-worker/src/init/init.js
+++ b/mail-worker/src/init/init.js
@@ -31,6 +31,7 @@ const dbInit = {
 		await this.v3_0DB(c);
 		await this.v3_1DB(c);
 		await this.v3_2DB(c);
+		await this.v3_3DB(c);
 		await settingService.refresh(c);
 		return c.text('success');
 	},
@@ -68,6 +69,14 @@ const dbInit = {
 			]);
 		} catch (e) {
 			console.warn(`跳过索引：${e.message}`);
+		}
+	},
+
+	async v3_3DB(c) {
+		try {
+			await c.env.db.prepare(`ALTER TABLE user ADD COLUMN bark_url TEXT NOT NULL DEFAULT '';`).run();
+		} catch (e) {
+			console.warn(`跳过字段：${e.message}`);
 		}
 	},
 

--- a/mail-worker/src/service/bark-service.js
+++ b/mail-worker/src/service/bark-service.js
@@ -1,0 +1,73 @@
+import orm from '../entity/orm';
+import user from '../entity/user';
+import { eq } from 'drizzle-orm';
+import { emailConst } from '../const/entity-const';
+
+const barkService = {
+
+	/**
+	 * 收到邮件后通过 Bark 推送通知到用户手机
+	 * 推送标题 = 收件箱地址（message.to），推送内容 = 邮件标题
+	 * 仅对收件（type=RECEIVE）触发，发件不通知
+	 *
+	 * @param c          Hono/Worker 上下文（含 env）
+	 * @param emailRow   邮件记录（含 toEmail、subject、userId、type 等）
+	 */
+	async notifyReceive(c, emailRow) {
+		try {
+			// 仅收件邮件触发 Bark 通知，发件不通知
+			if (emailRow.type !== emailConst.type.RECEIVE) {
+				return;
+			}
+
+			// userId 为 0 表示无人收件（无对应用户），不推送
+			if (!emailRow.userId || emailRow.userId === 0) {
+				return;
+			}
+
+			// 查询用户 barkUrl
+			const userRow = await orm(c).select({ barkUrl: user.barkUrl })
+				.from(user)
+				.where(eq(user.userId, emailRow.userId))
+				.get();
+
+			if (!userRow || !userRow.barkUrl) {
+				return;
+			}
+
+			const barkUrl = userRow.barkUrl.trim();
+			if (!barkUrl) {
+				return;
+			}
+
+			// 标题 = 收件箱地址，内容 = 邮件标题
+			const title = emailRow.toEmail || '';
+			const body = emailRow.subject || '';
+
+			// 支持 GET 路径格式和 POST JSON 格式
+			// 用户填写的 URL 形如：https://api.day.app/your_key
+			// 使用 POST JSON 方式推送
+			const res = await fetch(barkUrl, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json; charset=utf-8'
+				},
+				body: JSON.stringify({
+					title: title,
+					body: body,
+					group: 'CloudMail'
+				})
+			});
+
+			if (!res.ok) {
+				console.error(`Bark 推送失败 status: ${res.status} response: ${await res.text()}`);
+			}
+		} catch (e) {
+			// Bark 推送失败不影响邮件接收主流程
+			console.error('Bark 推送异常:', e.message);
+		}
+	}
+
+};
+
+export default barkService;

--- a/mail-worker/src/service/user-service.js
+++ b/mail-worker/src/service/user-service.js
@@ -96,6 +96,20 @@ const userService = {
 			.get();
 	},
 
+	async getBarkUrl(c, userId) {
+		const userRow = await this.selectById(c, userId);
+		return userRow?.barkUrl || '';
+	},
+
+	async setBarkUrl(c, params, userId) {
+		let { barkUrl } = params;
+		if (typeof barkUrl !== 'string') {
+			barkUrl = '';
+		}
+		barkUrl = barkUrl.trim();
+		await orm(c).update(user).set({ barkUrl }).where(eq(user.userId, userId)).run();
+	},
+
 	async delete(c, userId) {
 		const { syncDelete } = await settingService.query(c);
 		if (syncDelete === settingConst.syncDelete.OPEN) {


### PR DESCRIPTION
- Add Bark URL configuration in user settings page (per-user basis)
- New bark-service.js sends push via Bark API when an email is received
- Push title = recipient mailbox address, push body = email subject
- Only receiving emails triggers notification; sending does not
- Add bark_url column to user table with v3_3DB migration
- Add GET/PUT /my/barkUrl API for reading and saving the config
- Failure of Bark push does not affect the main email receive flow
- Add i18n entries for zh and en