### PR TITLE
fix: recover verification codes when AI JSON parse fails

### DIFF
--- a/mail-worker/src/email/email.js
+++ b/mail-worker/src/email/email.js
@@ -157,6 +157,8 @@ export async function email(message, env, ctx) {
 		}
 
 		emailRow = await emailService.completeReceive({ env }, account ? emailConst.status.RECEIVE : emailConst.status.NOONE, emailRow.emailId);
+		// webhook / TG 用官方 email.code，completeReceive 的 returning 有时不带这列
+		emailRow.code = code || emailRow.code || '';
 
 
 		if (ruleType === settingConst.ruleType.RULE) {

--- a/mail-worker/src/service/ai-service.js
+++ b/mail-worker/src/service/ai-service.js
@@ -1,5 +1,6 @@
 import emailUtils from '../utils/email-utils';
 import { settingConst } from '../const/entity-const';
+import { parseAiResult, extractCodeFromText } from '../utils/ai-code-parse';
 
 const aiService = {
 	async extractCode(c, email, options = {}) {
@@ -7,18 +8,22 @@ const aiService = {
 			return '';
 		}
 
+		const subject = email.subject || '';
+		const text = emailUtils.formatText(email.text || '');
+		const htmlText = emailUtils.htmlToText(email.html || '');
+		const body = (htmlText || text).slice(0, 6000);
+		const fallback = () => extractCodeFromText(`${subject}\n${body}`);
+
+		if (!subject && !body) {
+			return '';
+		}
+
 		const ai = c.env.ai;
+		if (!ai?.run) {
+			return fallback();
+		}
 
 		try {
-			const subject = email.subject || '';
-			const text = emailUtils.formatText(email.text || '');
-			const htmlText = emailUtils.htmlToText(email.html || '');
-			const body = (htmlText || text).slice(0, 6000);
-
-			if (!subject && !body) {
-				return '';
-			}
-
 			const result = await ai.run(c.env.ai_model || '@cf/meta/llama-3.1-8b-instruct-fast', {
 				messages: [
 					{
@@ -34,20 +39,10 @@ const aiService = {
 				max_tokens: 32
 			});
 
-			const content = typeof result === 'string' ? result : result?.response || '';
-			const json = typeof content === 'string' ? JSON.parse(content) : content;
-			if (typeof json.code !== 'string') {
-				return '';
-			}
-
-			if (json.code.length > 8 || /\s/.test(json.code)) {
-				return '';
-			}
-
-			return json.code;
+			return parseAiResult(result) || fallback();
 		} catch (e) {
 			console.error('验证码提取失败: ', e);
-			return '';
+			return fallback();
 		}
 	},
 

--- a/mail-worker/src/service/email-service.js
+++ b/mail-worker/src/service/email-service.js
@@ -170,6 +170,27 @@ const emailService = {
 		return conditions;
 	},
 
+	isVerifySearchKeyword(keyword) {
+		const key = String(keyword || '').trim().toLowerCase();
+		return [
+			'验证码', '校验码', '确认码', '確認碼', '驗證碼',
+			'动态密码', '動態密碼', '短信验证码',
+			'otp', 'pin', 'passcode', 'code',
+			'verification code', 'verify'
+		].includes(key);
+	},
+
+	allEmailKeywordMatch(column, keyword) {
+		const conds = [
+			sql`${column} COLLATE NOCASE LIKE ${keyword + '%'}`,
+			sql`${email.code} COLLATE NOCASE LIKE ${keyword + '%'}`,
+		];
+		if (this.isVerifySearchKeyword(keyword)) {
+			conds.push(ne(email.code, ''));
+		}
+		return or(...conds);
+	},
+
 	allEmailListFilters({ emailId, name, subject, accountEmail, userEmail, type, timeSort, withCursor = true }) {
 		const conditions = [];
 
@@ -203,11 +224,11 @@ const emailService = {
 		}
 
 		if (name) {
-			conditions.push(sql`${email.name} COLLATE NOCASE LIKE ${name + '%'}`);
+			conditions.push(this.allEmailKeywordMatch(email.name, name));
 		}
 
 		if (subject) {
-			conditions.push(sql`${email.subject} COLLATE NOCASE LIKE ${subject + '%'}`);
+			conditions.push(this.allEmailKeywordMatch(email.subject, subject));
 		}
 
 		if (withCursor && emailId) {

--- a/mail-worker/src/utils/ai-code-parse.js
+++ b/mail-worker/src/utils/ai-code-parse.js
@@ -1,0 +1,115 @@
+const TOKEN_RE = /^[A-Za-z0-9]{4,8}$/;
+const TITLE_CASE_RE = /^[A-Z][a-z]+$/;
+const STOPWORDS = new Set([
+	'hello', 'thanks', 'please', 'welcome', 'regards', 'yours',
+	'sincerely', 'dear', 'from', 'this', 'code', 'your', 'with',
+	'have', 'just', 'that', 'what'
+]);
+
+function normalizeCode(value) {
+	if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+		value = String(Math.trunc(value));
+	}
+	if (typeof value !== 'string') {
+		return '';
+	}
+	const code = value.trim();
+	if (!TOKEN_RE.test(code)) {
+		return '';
+	}
+	if (TITLE_CASE_RE.test(code) || STOPWORDS.has(code.toLowerCase())) {
+		return '';
+	}
+	return code;
+}
+
+function tryParseJson(text) {
+	if (typeof text !== 'string') {
+		return null;
+	}
+	const trimmed = text.trim();
+	try {
+		return JSON.parse(trimmed);
+	} catch {
+		// continue
+	}
+	const fence = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i);
+	if (fence) {
+		try {
+			return JSON.parse(fence[1].trim());
+		} catch {
+			// continue
+		}
+	}
+	const obj = trimmed.match(/\{[\s\S]*\}/);
+	if (obj) {
+		try {
+			return JSON.parse(obj[0]);
+		} catch {
+			// continue
+		}
+	}
+	return null;
+}
+
+function codeFromParsed(json) {
+	if (json == null) {
+		return '';
+	}
+	if (typeof json === 'number' || typeof json === 'string') {
+		return normalizeCode(json);
+	}
+	if (typeof json === 'object' && 'code' in json) {
+		return normalizeCode(json.code);
+	}
+	return '';
+}
+
+export function parseAiResult(result) {
+	if (result == null) {
+		return '';
+	}
+	if (typeof result === 'number') {
+		return normalizeCode(result);
+	}
+	if (typeof result === 'string') {
+		const json = tryParseJson(result);
+		if (json != null) {
+			const fromJson = codeFromParsed(json);
+			if (fromJson) {
+				return fromJson;
+			}
+		}
+		return normalizeCode(result);
+	}
+	if (typeof result === 'object') {
+		const fromSelf = codeFromParsed(result);
+		if (fromSelf) {
+			return fromSelf;
+		}
+		const inner = result.response ?? result.output ?? result.result;
+		if (inner !== undefined && inner !== result) {
+			return parseAiResult(inner);
+		}
+	}
+	return '';
+}
+
+// 不跨行：避免 "Your verification code\nHello" 把问候语当成码。
+// 短语放长的在前。简体/英文/短信转发都能命中。
+const PHRASE_RE = /(?:\b(?:(?:sms\s+)?verification code|one[-\s]?time (?:code|password|passcode)|security code|auth code|login code|otp(?:\s*code)?|passcode|pin code)\b|短信验证码|短信碼|短信码|动态密码|動態密碼|验证码|校验码|确认码|確認碼|驗證碼|確認コード)[ \t]*(?:is|code|为|為|是)?[ \t]*[:：=]?[ \t]*([A-Za-z0-9]{4,8})\b/i;
+
+export function extractCodeFromText(text) {
+	if (!text) {
+		return '';
+	}
+	const globalRe = new RegExp(PHRASE_RE.source, 'gi');
+	let match;
+	while ((match = globalRe.exec(String(text)))) {
+		const code = normalizeCode(match[1]);
+		if (code) {
+			return code;
+		}
+	}
+	return '';
+}

--- a/mail-worker/test/ai-code-parse.test.js
+++ b/mail-worker/test/ai-code-parse.test.js
@@ -1,0 +1,103 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseAiResult, extractCodeFromText } from '../src/utils/ai-code-parse.js';
+
+describe('parseAiResult', () => {
+	it('parses a JSON string with a string code', () => {
+		assert.equal(parseAiResult('{"code":"739284"}'), '739284');
+	});
+
+	it('accepts a numeric code', () => {
+		assert.equal(parseAiResult({ code: 739284 }), '739284');
+	});
+
+	it('reads Workers AI {response: jsonString}', () => {
+		assert.equal(parseAiResult({ response: '{"code":"739284"}' }), '739284');
+	});
+
+	it('reads Workers AI {response: object}', () => {
+		assert.equal(parseAiResult({ response: { code: '739284' } }), '739284');
+	});
+
+	it('extracts JSON wrapped in prose', () => {
+		assert.equal(parseAiResult('Here you go:\n```json\n{"code":"739284"}\n```'), '739284');
+	});
+
+	it('accepts a bare 4-8 character code from the model', () => {
+		assert.equal(parseAiResult('739284'), '739284');
+	});
+
+	it('accepts mixed alphanumeric codes', () => {
+		assert.equal(parseAiResult({ code: 'A8K2M1' }), 'A8K2M1');
+	});
+
+	it('accepts all-caps letter codes', () => {
+		assert.equal(parseAiResult({ code: 'XKLM' }), 'XKLM');
+	});
+
+	it('rejects codes longer than 8 characters', () => {
+		assert.equal(parseAiResult({ code: '123456789' }), '');
+	});
+
+	it('rejects codes that contain spaces', () => {
+		assert.equal(parseAiResult('{"code":"12 3456"}'), '');
+	});
+
+	it('rejects greeting words like Hello', () => {
+		assert.equal(parseAiResult({ response: '{"code":"Hello"}' }), '');
+	});
+});
+
+describe('extractCodeFromText', () => {
+	it('picks the code after "verification code is"', () => {
+		assert.equal(
+			extractCodeFromText('Your verification code is 739284.\nThis code expires in 10 minutes.'),
+			'739284'
+		);
+	});
+
+	it('picks a simplified Chinese 验证码 with mixed alnum', () => {
+		assert.equal(extractCodeFromText('您的验证码：A8K2M1，10分钟内有效'), 'A8K2M1');
+	});
+
+	it('picks 验证码紧贴数字（短信常见）', () => {
+		assert.equal(extractCodeFromText('【淘宝】验证码123456，切勿泄露'), '123456');
+	});
+
+	it('picks 校验码 / 确认码 / 动态密码', () => {
+		assert.equal(extractCodeFromText('校验码是 8821'), '8821');
+		assert.equal(extractCodeFromText('确认码：QWERTY'), 'QWERTY');
+		assert.equal(extractCodeFromText('动态密码为 Ab12Cd'), 'Ab12Cd');
+	});
+
+	it('picks English OTP / passcode / PIN', () => {
+		assert.equal(extractCodeFromText('Your OTP is 440188'), '440188');
+		assert.equal(extractCodeFromText('one-time passcode: XK4P9Q'), 'XK4P9Q');
+		assert.equal(extractCodeFromText('PIN code 882911'), '882911');
+	});
+
+	it('picks a code from a forwarded SMS email', () => {
+		assert.equal(
+			extractCodeFromText('转发短信\nFrom: +8613800138000\n【银行】短信验证码 440188，5分钟内有效'),
+			'440188'
+		);
+	});
+
+	it('picks a code from an English forwarded SMS', () => {
+		assert.equal(
+			extractCodeFromText('Forwarded SMS from +15551212:\nYour verification code is 562913'),
+			'562913'
+		);
+	});
+
+	it('returns empty when there is no verification phrasing', () => {
+		assert.equal(extractCodeFromText('Invoice 20260829 amount 123456'), '');
+	});
+
+	it('skips Hello after the subject and takes the real code', () => {
+		assert.equal(
+			extractCodeFromText('Your verification code\nHello,\n\nYour verification code is 481627.'),
+			'481627'
+		);
+	});
+});


### PR DESCRIPTION
Workers AI 返回不是纯 JSON 时，JSON.parse 会失败，email.code 被写成空。列表标签、全部邮件搜索、webhook、TG 都读这个官方字段，所以一起空。

改动：
- 继续写官方 email.code，不新增字段
- 兼容对象 / 数字 / 夹杂文本，AI 失败则从中英/短信正文兜底
- 全部邮件搜索同时匹配 code
- completeReceive 后把 code 写回，避免 webhook 丢字段