### PR TITLE
docs: document Cloudflare Email Service support

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -47,7 +47,7 @@ With only one domain, you can create multiple different email addresses, similar
 
 - **💻 Responsive Design**: Automatically adapts to both desktop and most mobile browsers.
 
-- **📧 Email Sending**: Integrated with Resend, supporting bulk email sending and attachments.
+- **📧 Email Sending**: Integrated with Cloudflare Email Service and Resend, supporting multiple recipients, inline images, attachments, and delivery status tracking.
 
 - **🛡️ Admin Features**: Admin controls for user and email management with RBAC-based access control.
 
@@ -79,7 +79,7 @@ With only one domain, you can create multiple different email addresses, similar
 
 - **UI Framework**: [Element Plus](https://element-plus.org/)
 
-- **Email Service**: [Resend](https://resend.com/)
+- **Email Service**: [Cloudflare Email Service](https://developers.cloudflare.com/email-service/) / [Resend](https://resend.com/)
 
 - **Cache**: [Cloudflare KV](https://developers.cloudflare.com/kv/)
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 
 - **💻 响应式设计**：响应式布局自动适配PC和大部分手机端浏览器
 
-- **📧 邮件发送**：集成Resend发送邮件，支持群发，内嵌图片和附件发送，发送状态查看
+- **📧 邮件发送**：集成 Cloudflare Email Service 和 Resend，支持群发、内嵌图片、附件发送和发送状态查看
 
 - **🛡️ 管理员功能**：可以对用户，邮件进行管理，RABC权限控制对功能及使用资源限制
 
@@ -86,7 +86,7 @@
 
 - **UI框架**：[Element Plus](https://element-plus.org/) 
 
-- **邮件推送：** [Resend](https://resend.com/)
+- **发信服务：** [Cloudflare Email Service](https://developers.cloudflare.com/email-service/) / [Resend](https://resend.com/)
 
 - **缓存**：[Cloudflare KV](https://developers.cloudflare.com/kv/)
 


### PR DESCRIPTION
## Summary

- Update the Chinese and English feature lists to mention Cloudflare Email Service alongside Resend.
- Update the tech stack sections to link to both supported email sending providers.

## Motivation

Cloudflare Email Service support is already implemented through the Workers send_email binding, while the README still describes Resend as the only email sending provider. This change brings both README files in line with the current implementation.

## Testing

- Ran git diff --check.
- No runtime tests were run because this change only updates documentation.