### PR TITLE
fix: harden Cloudflare email sending

### DIFF
--- a/mail-worker/src/const/constant.js
+++ b/mail-worker/src/const/constant.js
@@ -5,6 +5,8 @@ const constant = {
 	TOKEN_EXPIRE: 60 * 60 * 24 * 30,
 	ATTACHMENT_PREFIX: 'attachments/',
 	BACKGROUND_PREFIX: 'static/background/',
+	CF_EMAIL_RECIPIENT_LIMIT: 50,
+	CF_EMAIL_SIZE_LIMIT: 5 * 1024 * 1024,
 	ADMIN_ROLE: {
 		name: 'admin',
 		sendCount: 0,

--- a/mail-worker/src/i18n/en.js
+++ b/mail-worker/src/i18n/en.js
@@ -24,6 +24,7 @@ const en = {
 	senderAccountNotExist: 'Sender email does not exist',
 	noResendToken: 'Resend API token not configured',
 	noSendProvider: 'Email sending service is not configured',
+	cfEmailSizeLimit: 'The total size of the email content and attachments cannot exceed 5MB',
 	sendEmailNotCurUser: 'Sender email does not belong to current user',
 	notExistEmailReply: 'Mail does not exist and cannot be replied to',
 	imageAttLimit: 'The maximum number of image attachments is 10',

--- a/mail-worker/src/i18n/zh.js
+++ b/mail-worker/src/i18n/zh.js
@@ -24,6 +24,7 @@ const zh = {
 	senderAccountNotExist: '发件人邮箱不存在',
 	noResendToken: 'Resend未配置，只能给站内邮箱发件',
 	noSendProvider: '发信服务未配置，只能给站内邮箱发件',
+	cfEmailSizeLimit: '邮件内容和附件总大小不能超过5MB',
 	sendEmailNotCurUser: '发件人邮箱非当前用户所有',
 	notExistEmailReply: '邮件不存在无法回复',
 	imageAttLimit: '图片不能超过10个',

--- a/mail-worker/src/service/email-service.js
+++ b/mail-worker/src/service/email-service.js
@@ -23,6 +23,7 @@ import domainUtils from '../utils/domain-uitls';
 import account from "../entity/account";
 import { att } from '../entity/att';
 import telegramService from './telegram-service';
+import constant from '../const/constant';
 
 const emailService = {
 
@@ -472,9 +473,9 @@ const emailService = {
 	},
 
 	async sendByCloudflareEmail(c, params) {
+
 		const sendForm = {
 			from: { email: params.accountEmail, name: params.name },
-			to: [...params.receiveEmail],
 			subject: params.subject
 		};
 
@@ -498,13 +499,57 @@ const emailService = {
 			};
 		}
 
-		const result = await c.env.email.send(sendForm);
+		//超出cf单封邮件大小限制直接提示，避免拿到无法理解的错误
+		if (this.cloudflareEmailSize(sendForm) > constant.CF_EMAIL_SIZE_LIMIT) {
+			return { error: { message: t('cfEmailSizeLimit') } };
+		}
+
+		//cf单封邮件收件人不能超过50个，超出时分批发送
+		const batchList = [];
+		for (let index = 0; index < params.receiveEmail.length; index += constant.CF_EMAIL_RECIPIENT_LIMIT) {
+			batchList.push(params.receiveEmail.slice(index, index + constant.CF_EMAIL_RECIPIENT_LIMIT));
+		}
+
+		let messageId = null;
+
+		try {
+
+			for (const batch of batchList) {
+				const result = await c.env.email.send({ ...sendForm, to: [...batch] });
+				//分批发送时只保留第一封的消息id
+				messageId = messageId || result?.messageId;
+			}
+
+		} catch (e) {
+			//cf发信失败抛出的是普通异常，统一转换成和resend一样的结构
+			return { error: { message: e.message } };
+		}
 
 		return {
 			data: {
-				id: result.messageId
+				id: messageId
 			}
 		};
+	},
+
+	//估算cf单封邮件的大小，附件为base64需要还原成原始大小
+	cloudflareEmailSize(sendForm) {
+
+		let size = 0;
+
+		if (sendForm.text) {
+			size += new TextEncoder().encode(sendForm.text).length;
+		}
+
+		if (sendForm.html) {
+			size += new TextEncoder().encode(sendForm.html).length;
+		}
+
+		for (const attachment of sendForm.attachments || []) {
+			size += Math.floor(attachment.content.length * 3 / 4);
+		}
+
+		return size;
 	},
 
 	async sendByResend(resendToken, params) {
@@ -529,12 +574,21 @@ const emailService = {
 		return await resend.emails.send(sendForm);
 	},
 
-	async toCloudflareAttachments(attachments) {
-		const arrayBufferAttachments = await this.toArrayBufferAttachments(attachments);
+	async toCloudflareAttachments(attachments = []) {
 
-		return arrayBufferAttachments.map(attachment => {
+		const result = [];
+
+		for (const attachment of attachments) {
+
+			//cf本地开发不能序列化二进制附件，统一使用base64
+			const content = await this.toAttachmentBase64(attachment);
+
+			if (!content) {
+				continue;
+			}
+
 			const item = {
-				content: attachment.content,
+				content,
 				filename: attachment.filename,
 				type: attachment.mimeType || attachment.contentType || attachment.type || 'application/octet-stream',
 				disposition: attachment.contentId ? 'inline' : 'attachment'
@@ -544,8 +598,10 @@ const emailService = {
 				item.contentId = attachment.contentId.replace(/^<|>$/g, '');
 			}
 
-			return item;
-		});
+			result.push(item);
+		}
+
+		return result;
 	},
 
 	async toResendAttachments(attachments = []) {
@@ -562,21 +618,6 @@ const emailService = {
 				content,
 				contentType: attachment.contentType || attachment.mimeType || attachment.type || 'application/octet-stream'
 			});
-		}
-
-		return result;
-	},
-
-	async toArrayBufferAttachments(attachments = []) {
-		const result = [];
-
-		for (const attachment of attachments) {
-			const content = await this.toAttachmentArrayBuffer(attachment);
-			if (!content) {
-				continue;
-			}
-
-			result.push({ ...attachment, content });
 		}
 
 		return result;


### PR DESCRIPTION
- send attachments as base64: wrangler dev's local simulator cannot serialize ArrayBuffer attachment content, so any send with an attachment fails locally
- split recipients into batches of 50, the documented per-message limit for to + cc + bcc, instead of letting a larger group send fail outright
- check the 5 MiB message size limit up front and report a readable error
- catch errors from env.email.send(), which throws, and return them in the same { data, error } shape the caller already expects from Resend


Claude-Session: https://claude.ai/code/session_01Mw6xv9y5RaaBFXNGvrhTLo