### PR TITLE
fix: resolve blank email content via on-demand detail fetching and real-time cache

### DIFF
--- a/mail-vue/src/request/email.js
+++ b/mail-vue/src/request/email.js
@@ -12,6 +12,10 @@ export function emailLatest(emailId, accountId, allReceive) {
     return http.get('/email/latest', {params: {emailId, accountId, allReceive}, noMsg: true, timeout: 35 * 1000})
 }
 
+export function emailDetail(emailId) {
+    return http.get('/email/detail', {params: {emailId}, noMsg: true})
+}
+
 export function emailRead(emailIds) {
     return http.put('/email/read', {emailIds})
 }

--- a/mail-vue/src/store/email.js
+++ b/mail-vue/src/store/email.js
@@ -55,12 +55,16 @@ export const useEmailStore = defineStore('email', {
             if (id && this.detailMap[id]) {
                 return this.detailMap[id]
             }
+            if (email?.content || email?.text) {
+                if (id) this.detailMap[id] = email
+                return email
+            }
             return {
                 ...email,
                 emailId: id || 0,
-                content: '',
-                text: '',
-                attList: [],
+                content: email?.content || '',
+                text: email?.text || '',
+                attList: email?.attList || [],
                 recipient: email?.recipient || '[]',
             }
         },

--- a/mail-vue/src/views/all-email/index.vue
+++ b/mail-vue/src/views/all-email/index.vue
@@ -341,6 +341,7 @@ async function latest() {
 
       for (let email of list) {
 
+        emailStore.detailMap[email.emailId] = email
         sysEmailScroll.value.addItem(email)
         await sleep(50)
 

--- a/mail-vue/src/views/content/index.vue
+++ b/mail-vue/src/views/content/index.vue
@@ -35,8 +35,13 @@
             <el-alert v-if="email.status === 5" :closable="false" :title="$t('delayed')" class="email-msg" type="warning" show-icon />
           </div>
           <el-scrollbar class="htm-scrollbar" :class="!email.attList?.length ? 'bottom-distance' : ''">
-            <ShadowHtml class="shadow-html" :html="formatImage(email.content)" v-if="email.content" />
-            <pre v-else class="email-text" >{{email.text}}</pre>
+            <div v-if="detailLoading" style="padding: 20px 0;">
+              <el-skeleton :rows="8" animated />
+            </div>
+            <template v-else>
+              <ShadowHtml class="shadow-html" :html="formatImage(email.content)" v-if="email.content" />
+              <pre v-else class="email-text">{{ email.text }}</pre>
+            </template>
           </el-scrollbar>
           <div class="att" v-if="email.attList?.length > 0">
             <div class="att-title">
@@ -78,7 +83,7 @@ import ShadowHtml from '@/components/shadow-html/index.vue'
 import {computed, reactive, ref, watch, onMounted, onUnmounted} from "vue";
 import {useRouter} from 'vue-router'
 import {ElMessage, ElMessageBox} from 'element-plus'
-import {emailDelete, emailRead} from "@/request/email.js";
+import {emailDelete, emailRead, emailDetail} from "@/request/email.js";
 import {Icon} from "@iconify/vue";
 import {useEmailStore} from "@/store/email.js";
 import {useAccountStore} from "@/store/account.js";
@@ -107,6 +112,7 @@ const email = computed(() => emailStore.contentData.email || {
 })
 const showPreview = ref(false)
 const srcList = reactive([])
+const detailLoading = ref(false)
 
 const { t } = useI18n()
 watch(() => accountStore.currentAccountId, () => {
@@ -114,6 +120,35 @@ watch(() => accountStore.currentAccountId, () => {
 })
 
 let readRequesting = false
+
+function loadMissingDetail() {
+  const current = email.value
+  if (!current?.emailId) return
+
+  // 1. 優先檢查 detailMap 快取
+  const cached = emailStore.detailMap[current.emailId]
+  if (cached?.content || cached?.text) {
+    emailStore.contentData.email = cached
+    return
+  }
+
+  // 2. 若已有正文，無需重複拉取
+  if (current.content || current.text) return
+
+  // 3. 內文未就緒（如新郵件即時點擊或直接整理頁面），立即按需發起詳情請求
+  detailLoading.value = true
+  emailDetail(current.emailId).then(data => {
+    if (data) {
+      emailStore.detailMap[current.emailId] = data
+      emailStore.contentData.email = data
+    }
+  }).catch(err => {
+    console.error('Failed to load email detail:', err)
+  }).finally(() => {
+    detailLoading.value = false
+    tryMarkRead()
+  })
+}
 
 function tryMarkRead() {
   if (!emailStore.contentData.showUnread || readRequesting) return
@@ -148,7 +183,13 @@ watch(
   { flush: 'post' }
 )
 
+watch(
+  () => email.value?.emailId,
+  () => loadMissingDetail()
+)
+
 onMounted(() => {
+  loadMissingDetail()
   tryMarkRead()
   window.addEventListener('keydown', handleKeyDown);
 })

--- a/mail-vue/src/views/email/index.vue
+++ b/mail-vue/src/views/email/index.vue
@@ -110,6 +110,7 @@ async function latest() {
               if (!existIds.has(email.emailId)) {
 
                 existIds.add(email.emailId)
+                emailStore.detailMap[email.emailId] = email
                 scroll.value.addItem(email)
 
                 await sleep(50)

--- a/mail-worker/src/api/email-api.js
+++ b/mail-worker/src/api/email-api.js
@@ -14,6 +14,11 @@ app.get('/email/latest', async (c) => {
 	return c.json(result.ok(list));
 });
 
+app.get('/email/detail', async (c) => {
+	const data = await emailService.detail(c, c.req.query(), userContext.getUserId(c));
+	return c.json(result.ok(data));
+});
+
 app.delete('/email/delete', async (c) => {
 	await emailService.delete(c, c.req.query(), userContext.getUserId(c));
 	return c.json(result.ok());

--- a/mail-worker/src/service/email-service.js
+++ b/mail-worker/src/service/email-service.js
@@ -23,6 +23,7 @@ import domainUtils from '../utils/domain-uitls';
 import account from "../entity/account";
 import { att } from '../entity/att';
 import telegramService from './telegram-service';
+import userContext from '../security/user-context';
 
 const emailService = {
 
@@ -823,16 +824,58 @@ const emailService = {
 			.get();
 	},
 
+	async detail(c, params, userId) {
+		let { emailId } = params;
+		emailId = Number(emailId);
+		if (!emailId) {
+			throw new BizError(t(c, 'emptyParam'));
+		}
+
+		let emailRow = await orm(c).select().from(email).where(
+			and(
+				eq(email.emailId, emailId),
+				eq(email.userId, userId),
+				eq(email.isDel, isDel.NORMAL)
+			)
+		).get();
+
+		if (!emailRow) {
+			const user = userContext.getUser(c);
+			if (user && user.userEmail === c.env.admin) {
+				emailRow = await orm(c).select().from(email).where(
+					and(
+						eq(email.emailId, emailId),
+						eq(email.isDel, isDel.NORMAL)
+					)
+				).get();
+			}
+		}
+
+		if (!emailRow) {
+			throw new BizError(t(c, 'emailNotFound') || '郵件不存在');
+		}
+
+		const attList = await attService.selectByEmailIds(c, [emailId]);
+		emailRow.attList = attList || [];
+
+		const starRow = await orm(c).select({ starId: star.starId }).from(star).where(
+			and(eq(star.emailId, emailId), eq(star.userId, userId))
+		).get();
+		emailRow.isStar = starRow ? 1 : 0;
+
+		return emailRow;
+	},
+
 	async latest(c, params, userId) {
 		let { emailId, accountId, allReceive } = params;
 		allReceive = Number(allReceive);
 
 		if (isNaN(allReceive)) {
 			let accountRow = await accountService.selectById(c, accountId);
-			allReceive = accountRow.allReceive;
+			allReceive = accountRow?.allReceive || 0;
 		}
 
-		let list = await orm(c).select({ ...emailBriefColumns }).from(email)
+		let list = await orm(c).select({ ...emailListColumns }).from(email)
 			.innerJoin(
 				account,
 				eq(account.accountId, email.accountId)
@@ -849,7 +892,8 @@ const emailService = {
 			.orderBy(desc(email.emailId))
 			.limit(20);
 
-		return this.applyListText(list);
+		await this.emailAddAtt(c, list);
+		return list;
 	},
 
 	async physicsDelete(c, params) {
@@ -975,7 +1019,7 @@ const emailService = {
 
 		const { emailId } = params;
 
-		let list = await orm(c).select({ ...emailBriefColumns, userEmail: user.email }).from(email)
+		let list = await orm(c).select({ ...emailListColumns, userEmail: user.email }).from(email)
 			.leftJoin(user, eq(email.userId, user.userId))
 			.where(
 				and(
@@ -985,7 +1029,8 @@ const emailService = {
 			.orderBy(desc(email.emailId))
 			.limit(20);
 
-		return this.applyListText(list);
+		await this.emailAddAtt(c, list);
+		return list;
 	},
 
 	async emailAddAtt(c, list) {


### PR DESCRIPTION
### Summary of Changes

When a user clicks on a newly arrived email (polled via `emailLatest`) or navigates to an email before the background list `full=1` fetch completes, the email body (`content`) is empty (`""`), rendering a completely blank screen below the header until the user manually refreshes the page.

#### Root Causes
1. **Real-time Polling stripped `content` without caching**:
   In `emailService.latest`, the query used `emailBriefColumns` and called `applyListText(list)`, explicitly deleting `item.content`. The frontend `latest()` loop added the email item to the scroll list without populating `detailMap`.
2. **Missing Single Email Detail API**:
   The backend previously had no dedicated `/email/detail` endpoint to retrieve a single email's full body on demand.
3. **No Fallback / Self-Healing in `content/index.vue`**:
   `content/index.vue` only rendered whatever was in `emailStore.contentData.email`. If `content` was empty, it rendered an empty block indefinitely without attempting to fetch the details.

---

### Solutions Applied

1. **Backend (`mail-worker`)**:
   - Added `GET /email/detail?emailId=:emailId` in `email-api.js` and `emailService.detail` to fetch complete content and attachments for a specific email with permission checks.
   - Updated `emailService.latest` and `allEmailLatest` to query full columns and load attachments (`emailAddAtt`). Real-time polling typically returns only 1–2 items, so returning complete content introduces no performance penalty while eliminating race conditions.
2. **Frontend Store & Poller (`mail-vue`)**:
   - In `views/email/index.vue` and `views/all-email/index.vue`, newly polled emails are immediately cached into `emailStore.detailMap[email.emailId] = email`.
   - In `store/email.js`, `toContentEmail` retains `content` and `text` if already present in the passed object.
3. **Frontend Content View (`views/content/index.vue`):**
   - Added on-demand self-healing (`loadMissingDetail()`): If `content` is missing when opening an email, it displays an animated skeleton and immediately fetches the full email via `emailDetail(emailId)`, populating `detailMap` and rendering seamlessly.