### PR TITLE
fix: S3/R2 附件下载走统一存储代理

### DIFF
--- a/mail-vue/src/i18n/en.js
+++ b/mail-vue/src/i18n/en.js
@@ -166,7 +166,7 @@ const en = {
     codeRecognitionRulesDesc: 'Only recognize emails containing the following info. Empty means all.',
     oss: 'Object Storage',
     osDomain: 'Domain',
-    ossDomainDesc: 'Leave empty if using KV storage.',
+    ossDomainDesc: 'Leave empty for KV or S3 (this site proxies downloads). Fill in only when using a public R2/S3 CDN domain.',
     emailPush: 'Email Push',
     tgBot: 'Telegram Bot',
     disable: 'Disable',

--- a/mail-vue/src/i18n/zh.js
+++ b/mail-vue/src/i18n/zh.js
@@ -166,7 +166,7 @@ const zh = {
     codeRecognitionRulesDesc: '只识别包含以下信息的邮件，为空识别全部',
     oss: '对象存储',
     osDomain: '访问域名',
-    ossDomainDesc: '如果是KV存储不要填',
+    ossDomainDesc: 'KV / S3 可留空（附件由本站代理下载）；仅在使用 R2/S3 公有访问域名或 CDN 时再填写',
     emailPush: '邮件推送',
     tgBot: 'Telegram 机器人',
     disable: '关闭',

--- a/mail-vue/src/utils/convert.js
+++ b/mail-vue/src/utils/convert.js
@@ -2,10 +2,10 @@ import {useSettingStore} from "@/store/setting.js";
 export function cvtR2Url(key) {
 
     if (!key) {
-        return + 'https://' + ''
+        return ''
     }
 
-    if (key.startsWith('https://')) {
+    if (key.startsWith('https://') || key.startsWith('http://')) {
         return key
     }
 
@@ -13,8 +13,9 @@ export function cvtR2Url(key) {
 
     let domain = settings.r2Domain
 
+    // No public CDN domain: serve via this site's /attachments|/static|/oss proxy
     if (!domain) {
-        return key;
+        return '/' + String(key).replace(/^\//, '')
     }
 
     if (!domain.startsWith('http')) {

--- a/mail-worker/src/api/r2-api.js
+++ b/mail-worker/src/api/r2-api.js
@@ -3,13 +3,11 @@ import app from '../hono/hono';
 
 app.get('/oss/*', async (c) => {
 	const key = c.req.path.split('/oss/')[1];
-	const obj = await r2Service.getObj(c, key);
-	return new Response(obj.body, {
-		headers: {
-			'Content-Type': obj.httpMetadata?.contentType || 'application/octet-stream',
-			'Content-Disposition': obj.httpMetadata?.contentDisposition || null
-		}
-	});
+	const resp = await r2Service.toObjResp(c, key);
+	if (!resp) {
+		return c.notFound();
+	}
+	return resp;
 });
 
 

--- a/mail-worker/src/index.js
+++ b/mail-worker/src/index.js
@@ -3,7 +3,7 @@ import { email } from './email/email';
 import userService from './service/user-service';
 import verifyRecordService from './service/verify-record-service';
 import emailService from './service/email-service';
-import kvObjService from './service/kv-obj-service';
+import r2Service from './service/r2-service';
 import oauthService from './service/oauth-service';
 import analysisService from './service/analysis-service';
 export default {
@@ -17,8 +17,15 @@ export default {
 			return app.fetch(req, env, ctx);
 		}
 
+		if (url.pathname.startsWith('/oss/')) {
+			const key = url.pathname.slice('/oss/'.length);
+			const resp = await r2Service.toObjResp({ env }, key);
+			return resp || new Response('Not Found', { status: 404 });
+		}
+
 		 if (['/static/','/attachments/'].some(p => url.pathname.startsWith(p))) {
-			 return await kvObjService.toObjResp( { env }, url.pathname.substring(1));
+			 const resp = await r2Service.toObjResp({ env }, url.pathname.substring(1));
+			 return resp || new Response('Not Found', { status: 404 });
 		 }
 
 		return env.assets.fetch(req);

--- a/mail-worker/src/service/r2-service.js
+++ b/mail-worker/src/service/r2-service.js
@@ -56,6 +56,47 @@ const r2Service = {
 		}
 	},
 
+	/**
+	 * Always returns a Response (or null if missing) so HTTP handlers
+	 * can serve KV / R2 / S3 the same way.
+	 */
+	async toObjResp(c, key) {
+		try {
+			const storageType = await this.storageType(c);
+
+			if (storageType === 'KV') {
+				return await kvObjService.getObj(c, key);
+			}
+
+			if (storageType === 'R2') {
+				const obj = await c.env.r2.get(key);
+				if (!obj) {
+					return null;
+				}
+				return new Response(obj.body, {
+					headers: {
+						'Content-Type': obj.httpMetadata?.contentType || 'application/octet-stream',
+						'Content-Disposition': obj.httpMetadata?.contentDisposition || null,
+						'Cache-Control': obj.httpMetadata?.cacheControl || null
+					}
+				});
+			}
+
+			if (storageType === 'S3') {
+				return await s3Service.getObj(c, key);
+			}
+
+			return null;
+		} catch (e) {
+			const status = e?.$metadata?.httpStatusCode;
+			const code = e?.name || e?.Code || e?.code;
+			if (status === 404 || code === 'NoSuchKey' || code === 'NotFound') {
+				return null;
+			}
+			throw e;
+		}
+	},
+
 	async delete(c, key) {
 
 		const storageType = await this.storageType(c);


### PR DESCRIPTION
## Summary
- Configuring S3 made attachment **send** work, but **open/download** still failed: `/attachments/*` always read from KV, ignoring S3/R2.
- Route `/attachments`, `/static`, and `/oss` through `r2Service.toObjResp` so KV / R2 / S3 share one download path.
- Clarify OSS domain UX: leave empty for KV or S3 (this site proxies); fill in only for a public R2/S3 CDN domain.
- When OSS domain is empty, attachment URLs use a root-absolute path (`/attachments/...`) so deep routes do not break relative links.

## Test plan
- [x] With S3 configured and OSS domain empty: attachment preview/download works
- [x] `/attachments/<key>`, `/oss/<key>`, `/api/oss/<key>` all fetch from S3
- [x] Without S3 (KV or R2 only): attachments still work as before
- [x] Public R2/CDN domain still used when configured

Originally fixed and merged on the fork: https://github.com/mllt992/cloud-mail/pull/4